### PR TITLE
Remove BuildLogTask from utility project

### DIFF
--- a/playwright-utility/basement/utility.csproj
+++ b/playwright-utility/basement/utility.csproj
@@ -31,19 +31,4 @@
     <kcgXlibPath>../../../kcg-xlib</kcgXlibPath>
   </PropertyGroup>
 
-  <UsingTask AssemblyFile="$(OutputPath)build-log.dll" TaskName="MyTasks.BuildLogTask"/>
-
-  <Target Name="BuildLogTask" BeforeTargets="PostBuildEvent">
-    <PropertyGroup>
-      <BuildEndTimeUtc>$([System.DateTime]::UtcNow)</BuildEndTimeUtc>
-    </PropertyGroup>
-
-    <BuildLogTask
-            EventName="BuildLog"
-            LogFile="$(kcgXlibPath)/build-log/data/logs-build/build-log.json"
-            BuildStart="$(BuildStartTimeUtc)"
-            BuildEnd="$(BuildEndTimeUtc)"
-    />
-  </Target>
-
 </Project>


### PR DESCRIPTION
Eliminated the BuildLogTask and its associated UsingTask from the utility.csproj to streamline the build process and reduce complexity.