### PR TITLE
Remove unused project reference from utility.csproj

### DIFF
--- a/playwright-utility/basement/utility.csproj
+++ b/playwright-utility/basement/utility.csproj
@@ -18,7 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../network/network.csproj" />
     <ProjectReference Include="../../../kcg-xlib/xlib-io/xlib-io.csproj" />
     <ProjectReference Include="../../../kcg-xlib/xlib-http-server/xlib-http-server.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This change eliminates the reference to the network project, streamlining the project dependencies.