### PR TITLE
Fix casing for XlibHttpServer namespace

### DIFF
--- a/playwright-utility/basement/ExtractorHelper.cs
+++ b/playwright-utility/basement/ExtractorHelper.cs
@@ -3,7 +3,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using ImageMagick;
-using xlibHttpServer;
+using XlibHttpServer;
 
 namespace Utility;
 
@@ -24,7 +24,7 @@ public class ExtractorHelper
     {
         Interlocked.Increment(ref _downloadedImageCount);
     }
-    
+
     // create image file from byte array
     public static void SaveImageBytesToFile(byte[] imageBytes, string outputPath)
     {

--- a/proxy-manager/PlaywrightProxyChecker.cs
+++ b/proxy-manager/PlaywrightProxyChecker.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net;
-using xlibHttpServer;
+using XlibHttpServer;
 using StreamReader = System.IO.StreamReader;
 
 namespace PlaywrightProxyManager;


### PR DESCRIPTION
Updated the casing of the XlibHttpServer namespace in ExtractorHelper.cs and PlaywrightProxyChecker.cs for consistency.